### PR TITLE
Add proxy support and configurable download location

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "StoreListings"]
 	path = StoreListings
-	url = https://github.com/mjishnu/StoreListings
+	url = https://github.com/siator72/StoreListings

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "StoreListings"]
 	path = StoreListings
-	url = https://github.com/siator72/StoreListings
+	url = https://github.com/mjishnu/StoreListings

--- a/Raven/App.xaml.cs
+++ b/Raven/App.xaml.cs
@@ -99,6 +99,8 @@ public partial class App : Application
                     services.AddSingleton<IThemeSelectorService, ThemeSelectorService>();
                     services.AddSingleton<ILocaleService, LocaleService>();
                     services.AddSingleton<IArchitectureSelectorService, ArchitectureSelectorService>();
+                    services.AddSingleton<IProxyService>(_ => ProxyService.Instance);
+                    services.AddSingleton<DownloadLocationService>(_ => DownloadLocationService.Instance);
                     services.AddTransient<INavigationViewService, NavigationViewService>();
 
                     services.AddSingleton<IActivationService, ActivationService>();

--- a/Raven/Contracts/Services/IProxyService.cs
+++ b/Raven/Contracts/Services/IProxyService.cs
@@ -1,0 +1,37 @@
+using System.Net;
+
+using Raven.Models;
+
+namespace Raven.Contracts.Services;
+
+/// <summary>
+/// Central store of user-defined proxies plus the currently active one.
+/// When a proxy is active every HTTP client the app creates (Store API, FE3,
+/// delta downloads, full downloads, GitHub update checks) routes through it.
+/// </summary>
+public interface IProxyService
+{
+    /// <summary>All saved proxy entries (persisted across restarts).</summary>
+    IReadOnlyList<ProxyEntry> Proxies { get; }
+
+    /// <summary>The currently active proxy, or null when direct connection is used.</summary>
+    ProxyEntry? ActiveProxy { get; }
+
+    /// <summary>Raised after any change (add/remove/switch) so listeners can refresh.</summary>
+    event EventHandler? Changed;
+
+    Task InitializeAsync();
+
+    Task AddProxyAsync(ProxyEntry entry);
+
+    Task RemoveProxyAsync(string id);
+
+    /// <summary>Sets the active proxy. Pass null to disable proxying.</summary>
+    Task SetActiveProxyAsync(ProxyEntry? entry);
+
+    /// <summary>
+    /// The WebProxy to use for new HttpClient instances, or null for a direct
+    /// system-default connection. Read this when constructing handlers.
+    /// </summary>
+    IWebProxy? GetWebProxy();
+}

--- a/Raven/Helpers/DownloadHelper.cs
+++ b/Raven/Helpers/DownloadHelper.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Net;
+using System.Net.Http;
 using Microsoft.Extensions.Logging;
 using Downloader;
 using StoreListings.Library;
@@ -21,11 +22,31 @@ public sealed class DownloadHelper
         public void Report(T value) => handler(value);
     }
 
+    private static HttpClient? _deltaHttpClient;
+    private static IWebProxy? _deltaProxy;
+
     // Shared client for blockmap/delta downloads: reuses pooled CDN connections across
     // files of an install instead of paying a fresh DNS+TCP+TLS handshake per file.
     // PooledConnectionLifetime bounds DNS staleness for the long-lived client.
-    private static readonly HttpClient s_deltaHttpClient = new(
-        new SocketsHttpHandler { PooledConnectionLifetime = TimeSpan.FromMinutes(5) }
+    private static HttpClient s_deltaHttpClient => _deltaHttpClient ??= CreateDeltaClient();
+
+    /// <summary>Rebuilds the shared delta client so it routes through the given proxy (null = direct).</summary>
+    public static void ApplyProxy(IWebProxy? proxy)
+    {
+        if (_deltaProxy == proxy)
+            return;
+        _deltaProxy = proxy;
+        _deltaHttpClient?.Dispose();
+        _deltaHttpClient = null;
+    }
+
+    private static HttpClient CreateDeltaClient() => new(
+        new SocketsHttpHandler
+        {
+            PooledConnectionLifetime = TimeSpan.FromMinutes(5),
+            UseProxy = _deltaProxy is not null,
+            Proxy = _deltaProxy,
+        }
     );
 
     private static async Task DownloadAsync(
@@ -116,6 +137,9 @@ public sealed class DownloadHelper
             // Best practice for large files: avoid up-front reservation / pre-allocation.
             // Pre-allocating multi-GB files can look like a hang due to long disk writes.
             ReserveStorageSpaceBeforeStartingDownload = false,
+
+            // Route the download through the user's active proxy, if any.
+            RequestConfiguration = { Proxy = ProxyService.Instance.GetWebProxy() },
 
             // CRITICAL for large files: Disable parallel chunking.
             // With ParallelDownload=true, the library holds chunk data in memory before merging.
@@ -464,6 +488,7 @@ public sealed class DownloadHelper
                         {
                             ReserveStorageSpaceBeforeStartingDownload =
                                 config.ReserveStorageSpaceBeforeStartingDownload,
+                            RequestConfiguration = { Proxy = config.RequestConfiguration.Proxy },
                             ParallelDownload = false,
                             ChunkCount = 1,
                             ParallelCount = 1,

--- a/Raven/Models/ProxyEntry.cs
+++ b/Raven/Models/ProxyEntry.cs
@@ -1,0 +1,123 @@
+namespace Raven.Models;
+
+using System.Windows.Input;
+
+using Raven.Services;
+
+/// <summary>
+/// A user-defined HTTP(S) proxy entry that can be stored and activated from Settings.
+/// </summary>
+public class ProxyEntry
+{
+    public string Id { get; set; } = Guid.NewGuid().ToString("N");
+
+    /// <summary>Proxy scheme/type: http, socks5, or socks4.</summary>
+    public string Scheme { get; set; } = "http";
+
+    /// <summary>Friendly display name chosen by the user (e.g. "Home V2Ray").</summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>Proxy host name or IP address.</summary>
+    public string Host { get; set; } = string.Empty;
+
+    /// <summary>Proxy port.</summary>
+    public int Port { get; set; } = 8080;
+
+    /// <summary>Optional username for authenticated proxies. Empty when not needed.</summary>
+    public string Username { get; set; } = string.Empty;
+
+    /// <summary>Optional password for authenticated proxies. Empty when not needed.</summary>
+    public string Password { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Builds the proxy URI (scheme://[user:pass@]host:port), used both for display
+    /// and as input validation feedback. Returns null when the host is not a valid
+    /// host name / IP so callers can show a validation error instead of crashing.
+    /// </summary>
+    public Uri? TryToUri()
+    {
+        try
+        {
+            return ToUri();
+        }
+        catch (UriFormatException)
+        {
+            return null;
+        }
+    }
+
+    public Uri ToUri()
+    {
+        var scheme = string.IsNullOrWhiteSpace(Scheme) ? "http" : Scheme.Trim().ToLowerInvariant();
+        var builder = new UriBuilder
+        {
+            Scheme = scheme,
+            Host = Host.Trim(),
+            Port = Port,
+        };
+
+        if (!string.IsNullOrWhiteSpace(Username))
+        {
+            builder.UserName = Username;
+            if (!string.IsNullOrWhiteSpace(Password))
+                builder.Password = Password;
+        }
+
+        return builder.Uri;
+    }
+
+    /// <summary>
+    /// Strict host validation: exactly four numeric octets, each 0-255
+    /// (the ---.---.---.--- format). Domain names are rejected.
+    /// </summary>
+    public static bool IsValidHost(string host)
+    {
+        if (string.IsNullOrWhiteSpace(host))
+            return false;
+
+        var parts = host.Trim().Split('.');
+        if (parts.Length != 4)
+            return false;
+
+        foreach (var part in parts)
+        {
+            if (part.Length is 0 or > 3
+                || !part.All(char.IsAsciiDigit)
+                || !int.TryParse(part, out var octet)
+                || octet > 255)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public override string ToString() => string.IsNullOrWhiteSpace(Name)
+        ? $"{Host}:{Port}"
+        : Name;
+
+    /// <summary>"scheme://host:port" (plus user hint) shown under the entry name in the UI.</summary>
+    public string AddressText
+    {
+        get
+        {
+            var scheme = string.IsNullOrWhiteSpace(Scheme) ? "http" : Scheme.Trim().ToLowerInvariant();
+            var baseText = $"{scheme}://{Host}:{Port}";
+            return string.IsNullOrWhiteSpace(Username)
+                ? baseText
+                : $"{baseText} ({Username})";
+        }
+    }
+
+    /// <summary>Commands wired by ProxyService so the Settings list can activate/remove this entry.</summary>
+    [System.Text.Json.Serialization.JsonIgnore]
+    public ICommand ActivateCommand => ProxyService.Instance.ActivateEntryCommand;
+
+    [System.Text.Json.Serialization.JsonIgnore]
+    public ICommand RemoveCommand => ProxyService.Instance.RemoveEntryCommand;
+
+    /// <summary>UI-only flag: true when this entry is the active proxy. Set by ProxyService.</summary>
+    [System.Text.Json.Serialization.JsonIgnore]
+    public bool IsActive { get; set; }
+}

--- a/Raven/Services/ActivationService.cs
+++ b/Raven/Services/ActivationService.cs
@@ -68,6 +68,13 @@ public class ActivationService : IActivationService
         await _themeSelectorService.InitializeAsync().ConfigureAwait(false);
         await _localeService.InitializeAsync().ConfigureAwait(false);
         await _architectureSelectorService.InitializeAsync().ConfigureAwait(false);
+
+        // Proxy must be initialized before any HTTP client is created, so the Store
+        // API and update checks route through the user's saved proxy from launch.
+        var proxyService = App.GetService<IProxyService>();
+        await proxyService.InitializeAsync().ConfigureAwait(false);
+
+        await App.GetService<DownloadLocationService>().InitializeAsync().ConfigureAwait(false);
     }
 
     private async Task StartupAsync()

--- a/Raven/Services/DownloadLocationService.cs
+++ b/Raven/Services/DownloadLocationService.cs
@@ -1,0 +1,48 @@
+using Raven.Contracts.Services;
+
+namespace Raven.Services;
+
+/// <summary>
+/// Persists the user's preferred download root folder. When unset, downloads go to
+/// %USERPROFILE%\Downloads\Raven (the app default).
+/// </summary>
+public class DownloadLocationService
+{
+    private const string DownloadFolderKey = "CustomDownloadFolder";
+
+    /// <summary>Static access for code paths outside DI (DownloadManagerService).</summary>
+    public static DownloadLocationService Instance => _instance.Value;
+
+    // Single shared instance used both by DI and the static accessor, so state set via
+    // SetDownloadFolderAsync is always visible to GetDownloadsRootFolder().
+    private static readonly Lazy<DownloadLocationService> _instance = new(() =>
+        new DownloadLocationService(App.GetService<ILocalSettingsService>())
+    );
+
+    private readonly ILocalSettingsService _localSettingsService;
+
+    public DownloadLocationService(ILocalSettingsService localSettingsService)
+    {
+        _localSettingsService = localSettingsService;
+    }
+
+    /// <summary>The configured custom folder, or null when using the default location.</summary>
+    public string? ConfiguredDownloadFolder { get; private set; }
+
+    /// <summary>The folder new downloads will land in right now (resolved default included).</summary>
+    public string EffectiveDownloadFolder =>
+        string.IsNullOrWhiteSpace(ConfiguredDownloadFolder)
+            ? DownloadManagerService.GetDefaultDownloadsRootFolder()
+            : ConfiguredDownloadFolder;
+
+    public async Task InitializeAsync()
+    {
+        ConfiguredDownloadFolder = await _localSettingsService.ReadSettingAsync<string>(DownloadFolderKey);
+    }
+
+    public async Task SetDownloadFolderAsync(string? folder)
+    {
+        ConfiguredDownloadFolder = string.IsNullOrWhiteSpace(folder) ? null : folder;
+        await _localSettingsService.SaveSettingAsync(DownloadFolderKey, ConfiguredDownloadFolder);
+    }
+}

--- a/Raven/Services/DownloadManagerService.cs
+++ b/Raven/Services/DownloadManagerService.cs
@@ -59,10 +59,25 @@ public class DownloadManagerService
             or DownloadStatus.Installing
             or DownloadStatus.Cancelling;
 
-    public static string GetDownloadsRootFolder() => Path.Combine(
-        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-        "Raven",
-        "Downloads"
+    public static string GetDownloadsRootFolder()
+    {
+        // User-configured download folder wins; fall back to %LOCALAPPDATA%\Raven\Downloads.
+        var configured = DownloadLocationService.Instance.ConfiguredDownloadFolder;
+        if (!string.IsNullOrWhiteSpace(configured))
+            return configured;
+
+        return Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+            "Raven",
+            "Downloads"
+        );
+    }
+
+    /// <summary>Default location used when the user has not chosen a custom folder.</summary>
+    public static string GetDefaultDownloadsRootFolder() => Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+        "Downloads",
+        "Raven"
     );
 
     private DownloadItem? TouchDownload(string productId)

--- a/Raven/Services/GitHubUpdaterService.cs
+++ b/Raven/Services/GitHubUpdaterService.cs
@@ -1,5 +1,7 @@
 using System.Diagnostics;
 using System.IO.Compression;
+using System.Net;
+using System.Net.Http;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text.Json;
@@ -8,7 +10,20 @@ namespace Raven.Services;
 
 public sealed class GitHubUpdaterService
 {
-    private static readonly HttpClient HttpClient = CreateHttpClient();
+    private static HttpClient? _httpClient;
+    private static IWebProxy? _proxy;
+
+    private static HttpClient HttpClient => _httpClient ??= CreateHttpClient();
+
+    /// <summary>Rebuilds the update-check client so it routes through the given proxy (null = direct).</summary>
+    public static void ApplyProxy(IWebProxy? proxy)
+    {
+        if (_proxy == proxy)
+            return;
+        _proxy = proxy;
+        _httpClient?.Dispose();
+        _httpClient = null;
+    }
 
     public static async Task<GitHubReleaseInfo> GetLatestReleaseAsync(CancellationToken cancellationToken = default)
     {
@@ -275,7 +290,11 @@ public sealed class GitHubUpdaterService
 
     private static HttpClient CreateHttpClient()
     {
-        var client = new HttpClient();
+        var client = new HttpClient(new SocketsHttpHandler
+        {
+            UseProxy = _proxy is not null,
+            Proxy = _proxy,
+        });
         client.DefaultRequestHeaders.UserAgent.ParseAdd("Raven-Updater");
         client.DefaultRequestHeaders.Accept.ParseAdd("application/vnd.github+json");
         return client;

--- a/Raven/Services/ProxyService.cs
+++ b/Raven/Services/ProxyService.cs
@@ -1,0 +1,227 @@
+using System.Net;
+
+using Raven.Contracts.Services;
+using Raven.Helpers;
+using Raven.Models;
+
+namespace Raven.Services;
+
+/// <summary>
+/// Persists the user's proxy list in LocalSettings.json and exposes the active
+/// proxy to every HTTP client factory in the app. The active proxy is stored by
+/// id so renaming an entry keeps it selected.
+/// </summary>
+public class ProxyService : IProxyService
+{
+    private const string ProxiesSettingsKey = "SavedProxies";
+    private const string ActiveProxyIdKey = "ActiveProxyId";
+
+    /// <summary>Static access for code paths outside DI (DownloadHelper).</summary>
+    public static ProxyService Instance => _instance.Value;
+
+    private static readonly Lazy<ProxyService> _instance = new(() =>
+        new ProxyService(App.GetService<ILocalSettingsService>())
+    );
+
+    private readonly ILocalSettingsService _localSettingsService;
+    private readonly object _lock = new();
+
+    private List<ProxyEntry> _proxies = [];
+    private string? _activeProxyId;
+
+    public event EventHandler? Changed;
+
+    public ProxyService(ILocalSettingsService localSettingsService)
+    {
+        _localSettingsService = localSettingsService;
+    }
+
+    public IReadOnlyList<ProxyEntry> Proxies
+    {
+        get { lock (_lock) return _proxies.ToList(); }
+    }
+
+    public ProxyEntry? ActiveProxy
+    {
+        get
+        {
+            lock (_lock)
+            {
+                return _activeProxyId is null
+                    ? null
+                    : _proxies.FirstOrDefault(p => p.Id == _activeProxyId);
+            }
+        }
+    }
+
+    public async Task InitializeAsync()
+    {
+        var saved = await _localSettingsService.ReadSettingAsync<List<ProxyEntry>>(ProxiesSettingsKey);
+        if (saved is not null)
+        {
+            lock (_lock)
+                _proxies = saved.Where(p => !string.IsNullOrWhiteSpace(p?.Host)).ToList();
+        }
+
+        var activeId = await _localSettingsService.ReadSettingAsync<string>(ActiveProxyIdKey);
+        lock (_lock)
+        {
+            // Older builds double-serialized the id (stored as "\"id\""); trim stray quotes.
+            activeId = activeId?.Trim().Trim('"');
+
+            // Only keep the saved selection when it still points at a known entry.
+            _activeProxyId = activeId is not null && _proxies.Any(p => p.Id == activeId)
+                ? activeId
+                : null;
+        }
+
+        RefreshActiveFlags();
+        Changed?.Invoke(this, EventArgs.Empty);
+    }
+
+    public async Task AddProxyAsync(ProxyEntry entry)
+    {
+        if (entry is null || string.IsNullOrWhiteSpace(entry.Host))
+            return;
+
+        // First proxy added becomes active immediately — the user adding one clearly
+        // wants it used; further adds stay passive until switched to.
+        bool shouldActivate;
+        lock (_lock)
+        {
+            entry.Name = string.IsNullOrWhiteSpace(entry.Name)
+                ? $"Proxy {_proxies.Count + 1}"
+                : entry.Name.Trim();
+            _proxies.Add(entry);
+            shouldActivate = _activeProxyId is null;
+            if (shouldActivate)
+                _activeProxyId = entry.Id;
+        }
+
+        await PersistAsync();
+        if (!shouldActivate)
+            Changed?.Invoke(this, EventArgs.Empty);
+        else
+            await SetActiveProxyAsync(GetById(_activeProxyId));
+    }
+
+    public async Task RemoveProxyAsync(string id)
+    {
+        bool wasActive;
+        lock (_lock)
+        {
+            wasActive = _activeProxyId == id;
+            _proxies.RemoveAll(p => p.Id == id);
+            if (wasActive)
+                _activeProxyId = null;
+        }
+
+        await PersistAsync();
+
+        if (wasActive)
+            await ApplyActiveProxyAsync(null);
+        else
+            Changed?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <summary>Marks the active entry so radio buttons in the UI show the right state.</summary>
+    private void RefreshActiveFlags()
+    {
+        var active = ActiveProxy;
+        lock (_lock)
+        {
+            foreach (var p in _proxies)
+                p.IsActive = active is not null && ReferenceEquals(p, active);
+        }
+    }
+
+    public async Task SetActiveProxyAsync(ProxyEntry? entry)
+    {
+        lock (_lock)
+            _activeProxyId = entry?.Id;
+
+        await PersistAsync();
+        await ApplyActiveProxyAsync(GetWebProxy());
+    }
+
+    public IWebProxy? GetWebProxy()
+    {
+        var proxy = ActiveProxy;
+        if (proxy is null)
+            return null;
+
+        var uri = proxy.TryToUri();
+        if (uri is null)
+            return null;
+
+        var webProxy = new WebProxy(uri);
+
+        // SOCKS auth must go through Credentials (user/pass in the URL is ignored).
+        if (!string.IsNullOrWhiteSpace(proxy.Username))
+            webProxy.Credentials = new NetworkCredential(proxy.Username, proxy.Password);
+
+        return webProxy;
+    }
+
+    /// <summary>Shared commands the Settings list binds per-entry via x:Bind.</summary>
+    public System.Windows.Input.ICommand ActivateEntryCommand { get; } =
+        new CommunityToolkit.Mvvm.Input.RelayCommand<ProxyEntry>(async entry =>
+        {
+            if (entry is not null)
+                await Instance.SetActiveProxyAsync(entry);
+        });
+
+    public System.Windows.Input.ICommand RemoveEntryCommand { get; } =
+        new CommunityToolkit.Mvvm.Input.RelayCommand<ProxyEntry>(entry =>
+        {
+            // Temp debug logging (remove once confirmed).
+            try
+            {
+                System.IO.File.AppendAllText(
+                    Path.Combine(
+                        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+                        "Raven", "proxy-debug.log"),
+                    $"{DateTime.Now:HH:mm:ss.fff} Remove clicked id={entry?.Id ?? "<null>"}\n");
+            }
+            catch { }
+
+            if (entry is not null)
+                _ = Instance.RemoveProxyAsync(entry.Id);
+        });
+
+    private ProxyEntry? GetById(string? id)
+    {
+        if (id is null)
+            return null;
+        lock (_lock)
+            return _proxies.FirstOrDefault(p => p.Id == id);
+    }
+
+    private async Task ApplyActiveProxyAsync(IWebProxy? webProxy)
+    {
+        // Push the new proxy into every shared client the app owns, then notify UI.
+        StoreListings.Library.Internal.ProxyManager.SetProxy(webProxy);
+        DownloadHelper.ApplyProxy(webProxy);
+        GitHubUpdaterService.ApplyProxy(webProxy);
+
+        RefreshActiveFlags();
+        Changed?.Invoke(this, EventArgs.Empty);
+        await Task.CompletedTask;
+    }
+
+    private async Task PersistAsync()
+    {
+        List<ProxyEntry> snapshot;
+        string? activeId;
+        lock (_lock)
+        {
+            snapshot = _proxies.ToList();
+            activeId = _activeProxyId;
+        }
+
+        await _localSettingsService.SaveSettingAsync(ProxiesSettingsKey, snapshot);
+        await _localSettingsService.SaveSettingAsync(ActiveProxyIdKey, activeId is null
+            ? null
+            : activeId.Trim().Trim('"'));
+    }
+}

--- a/Raven/Strings/en-us/Resources.resw
+++ b/Raven/Strings/en-us/Resources.resw
@@ -951,4 +951,73 @@ You can enable it by turning on Developer Mode in Windows Settings.</value>
   <data name="InstallationsPage_InstallDependenciesSeparately.Content" xml:space="preserve">
     <value>Install dependencies separately</value>
   </data>
+  <data name="Settings_Proxy.Text" xml:space="preserve">
+    <value>Proxy</value>
+  </data>
+  <data name="Settings_ProxyDescription.Text" xml:space="preserve">
+    <value>Save multiple proxies and switch between them at any time. All app traffic (Store API, downloads, update checks) uses the selected proxy. Choose "Direct connection" to disable proxying.</value>
+  </data>
+  <data name="Settings_Proxy_Direct.Content" xml:space="preserve">
+    <value>Direct connection (no proxy)</value>
+  </data>
+  <data name="Settings_Proxy_AddTitle.Text" xml:space="preserve">
+    <value>Add a new proxy</value>
+  </data>
+  <data name="Settings_Proxy_NameBox.PlaceholderText" xml:space="preserve">
+    <value>Name (optional)</value>
+  </data>
+  <data name="Settings_Proxy_HostBox.PlaceholderText" xml:space="preserve">
+    <value>Host or IP</value>
+  </data>
+  <data name="Settings_Proxy_PortBox.PlaceholderText" xml:space="preserve">
+    <value>Port</value>
+  </data>
+  <data name="Settings_Proxy_UsernameBox.PlaceholderText" xml:space="preserve">
+    <value>Username (optional)</value>
+  </data>
+  <data name="Settings_Proxy_PasswordBox.PlaceholderText" xml:space="preserve">
+    <value>Password (optional)</value>
+  </data>
+  <data name="Settings_Proxy_TypeCombo.PlaceholderText" xml:space="preserve">
+    <value>Type</value>
+  </data>
+  <data name="Settings_Proxy_AddButton.Content" xml:space="preserve">
+    <value>Add proxy</value>
+  </data>
+  <data name="Settings_Proxy_RemoveButton.Content" xml:space="preserve">
+    <value>Remove</value>
+  </data>
+  <data name="Settings_Proxy_Error_Chip.Text" xml:space="preserve">
+    <value>Wrong proxy</value>
+  </data>
+  <data name="Settings_Proxy_Error.Title" xml:space="preserve">
+    <value>Wrong proxy</value>
+  </data>
+  <data name="Settings_Proxy_Error_HostRequired" xml:space="preserve">
+    <value>Please enter a host name or IP address.</value>
+  </data>
+  <data name="Settings_Proxy_Error_PortInvalid" xml:space="preserve">
+    <value>Please enter a valid port number (1-65535).</value>
+  </data>
+  <data name="Settings_Proxy_Error_HostInvalid" xml:space="preserve">
+    <value>Invalid IP. The format is ---.---.---.--- — four groups of up to three digits (0-255), e.g. 127.0.0.1</value>
+  </data>
+  <data name="Settings_DownloadFolder.Text" xml:space="preserve">
+    <value>Download location</value>
+  </data>
+  <data name="Settings_DownloadFolderDescription.Text" xml:space="preserve">
+    <value>New downloads are saved to the folder below. The default is Downloads\Raven.</value>
+  </data>
+  <data name="Settings_DownloadFolder_CurrentLabel.Text" xml:space="preserve">
+    <value>Current download folder</value>
+  </data>
+  <data name="Settings_DownloadFolder_BrowseButton.Content" xml:space="preserve">
+    <value>Change folder</value>
+  </data>
+  <data name="Settings_DownloadFolder_ResetButton.Content" xml:space="preserve">
+    <value>Use default</value>
+  </data>
+  <data name="Settings_DownloadFolder_PickerTitle" xml:space="preserve">
+    <value>Select download folder</value>
+  </data>
 </root>

--- a/Raven/ViewModels/SettingsViewModel.cs
+++ b/Raven/ViewModels/SettingsViewModel.cs
@@ -6,6 +6,7 @@ using CommunityToolkit.Mvvm.Input;
 using Microsoft.UI.Xaml;
 using Raven.Contracts.Services;
 using Raven.Helpers;
+using Raven.Models;
 using Raven.Services;
 using StoreListings.Library;
 
@@ -16,6 +17,7 @@ public partial class SettingsViewModel : ObservableRecipient
     private readonly IThemeSelectorService _themeSelectorService;
     private readonly ILocaleService _localeService;
     private readonly IArchitectureSelectorService _architectureSelectorService;
+    private readonly IProxyService _proxyService;
     private bool _isInitialized;
 
     [ObservableProperty]
@@ -71,12 +73,15 @@ public partial class SettingsViewModel : ObservableRecipient
     public SettingsViewModel(
         IThemeSelectorService themeSelectorService,
         ILocaleService localeService,
-        IArchitectureSelectorService architectureSelectorService
+        IArchitectureSelectorService architectureSelectorService,
+        IProxyService proxyService
     )
     {
         _themeSelectorService = themeSelectorService;
         _localeService = localeService;
         _architectureSelectorService = architectureSelectorService;
+        _proxyService = proxyService;
+        _proxyService.Changed += (_, _) => RefreshProxySelection();
         _elementTheme = _themeSelectorService.Theme;
         _versionDescription = GetVersionDescription();
 
@@ -187,6 +192,168 @@ public partial class SettingsViewModel : ObservableRecipient
         {
             return lang.ToString();
         }
+    }
+
+    // ------------------------------------------------------------------
+    // Proxy management
+    // ------------------------------------------------------------------
+
+    public IReadOnlyList<ProxyEntry> Proxies => _proxyService.Proxies;
+
+    [ObservableProperty]
+    private ProxyEntry? _selectedProxy;
+
+    /// <summary>True when the user wants a direct connection (no proxy).</summary>
+    [ObservableProperty]
+    private bool _isDirectConnectionSelected;
+
+    // New-proxy form fields
+    [ObservableProperty]
+    private string _newProxyName = string.Empty;
+
+    /// <summary>Index into ProxySchemeNames for the type combo (http/socks5/socks4).</summary>
+    [ObservableProperty]
+    private int _newProxySchemeIndex;
+
+    [ObservableProperty]
+    private string _newProxyHost = string.Empty;
+
+    [ObservableProperty]
+    private string _newProxyPort = string.Empty;
+
+    [ObservableProperty]
+    private string _newProxyUsername = string.Empty;
+
+    [ObservableProperty]
+    private string _newProxyPassword = string.Empty;
+
+    [ObservableProperty]
+    private string _newProxyError = string.Empty;
+
+    public bool HasNewProxyError => !string.IsNullOrEmpty(NewProxyError);
+
+    /// <summary>Selectable proxy types.</summary>
+    public IReadOnlyList<string> ProxySchemeNames { get; } = ["HTTP", "HTTPS", "SOCKS4", "SOCKS5"];
+
+    partial void OnNewProxyErrorChanged(string value) => OnPropertyChanged(nameof(HasNewProxyError));
+
+    public ICommand AddProxyCommand => field ??= new AsyncRelayCommand(AddProxyAsync);
+    public ICommand RemoveProxyCommand => field ??= new AsyncRelayCommand<ProxyEntry>(RemoveProxyAsync!);
+    public ICommand ActivateProxyCommand => field ??= new AsyncRelayCommand<ProxyEntry>(ActivateProxyAsync!);
+    public ICommand UseDirectConnectionCommand => field ??= new AsyncRelayCommand(UseDirectConnectionAsync);
+
+    private async Task AddProxyAsync()
+    {
+        NewProxyError = string.Empty;
+
+        var host = NewProxyHost.Trim();
+        if (string.IsNullOrWhiteSpace(host))
+        {
+            NewProxyError = "Settings_Proxy_Error_HostRequired".GetLocalized();
+            return;
+        }
+
+        if (!int.TryParse(NewProxyPort.Trim(), out var port) || port is < 1 or > 65535)
+        {
+            NewProxyError = "Settings_Proxy_Error_PortInvalid".GetLocalized();
+            return;
+        }
+
+        var scheme = NewProxySchemeIndex >= 0 && NewProxySchemeIndex < ProxySchemeNames.Count
+            ? ProxySchemeNames[NewProxySchemeIndex].ToLowerInvariant()
+            : "http";
+
+        // Full URI validation up-front: reject hosts Uri would choke on (spaces,
+        // invalid chars, "host:port" pasted into the host box, ...) with a friendly
+        // error instead of a crash later when the proxy is activated.
+        if (!ProxyEntry.IsValidHost(host))
+        {
+            NewProxyError = "Settings_Proxy_Error_HostInvalid".GetLocalized();
+            return;
+        }
+
+        var entry = new ProxyEntry
+        {
+            Name = string.IsNullOrWhiteSpace(NewProxyName) ? $"Proxy {Proxies.Count + 1}" : NewProxyName.Trim(),
+            Scheme = scheme,
+            Host = host,
+            Port = port,
+            Username = NewProxyUsername.Trim(),
+            Password = NewProxyPassword,
+        };
+
+        await _proxyService.AddProxyAsync(entry);
+
+        // Reset the form.
+        NewProxyName = NewProxyHost = NewProxyPort = NewProxyUsername = NewProxyPassword = string.Empty;
+        NewProxySchemeIndex = 0;
+        RefreshProxySelection();
+    }
+
+    private async Task RemoveProxyAsync(ProxyEntry entry)
+    {
+        await _proxyService.RemoveProxyAsync(entry.Id);
+        RefreshProxySelection();
+    }
+
+    private async Task ActivateProxyAsync(ProxyEntry entry)
+    {
+        await _proxyService.SetActiveProxyAsync(entry);
+        RefreshProxySelection();
+    }
+
+    private async Task UseDirectConnectionAsync()
+    {
+        await _proxyService.SetActiveProxyAsync(null);
+        RefreshProxySelection();
+    }
+
+    private void RefreshProxySelection()
+    {
+        OnPropertyChanged(nameof(Proxies));
+        IsDirectConnectionSelected = _proxyService.ActiveProxy is null;
+        SelectedProxy = _proxyService.ActiveProxy;
+    }
+
+    // ------------------------------------------------------------------
+    // Download folder
+    // ------------------------------------------------------------------
+
+    [ObservableProperty]
+    private string _effectiveDownloadFolder =
+        DownloadLocationService.Instance.EffectiveDownloadFolder;
+
+    [ObservableProperty]
+    private bool _isUsingDefaultDownloadFolder =
+        string.IsNullOrWhiteSpace(DownloadLocationService.Instance.ConfiguredDownloadFolder);
+
+    public bool IsUsingDefaultDownloadFolderInverse => !IsUsingDefaultDownloadFolder;
+
+    partial void OnIsUsingDefaultDownloadFolderChanged(bool value) =>
+        OnPropertyChanged(nameof(IsUsingDefaultDownloadFolderInverse));
+
+    public ICommand BrowseDownloadFolderCommand => field ??= new AsyncRelayCommand(BrowseDownloadFolderAsync);
+    public ICommand ResetDownloadFolderCommand => field ??= new AsyncRelayCommand(ResetDownloadFolderAsync);
+
+    private async Task BrowseDownloadFolderAsync()
+    {
+        var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(App.MainWindow);
+        var folder = NativeFilePicker.PickFolder(
+            hwnd, "Settings_DownloadFolder_PickerTitle".GetLocalized());
+
+        if (string.IsNullOrWhiteSpace(folder))
+            return;
+
+        await App.GetService<DownloadLocationService>().SetDownloadFolderAsync(folder);
+        EffectiveDownloadFolder = folder;
+        IsUsingDefaultDownloadFolder = false;
+    }
+
+    private async Task ResetDownloadFolderAsync()
+    {
+        await App.GetService<DownloadLocationService>().SetDownloadFolderAsync(null);
+        EffectiveDownloadFolder = DownloadLocationService.Instance.EffectiveDownloadFolder;
+        IsUsingDefaultDownloadFolder = true;
     }
 
     public async Task ResetAppToDefaultAsync()

--- a/Raven/Views/SettingsPage.xaml
+++ b/Raven/Views/SettingsPage.xaml
@@ -5,10 +5,12 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:helpers="using:Raven.Helpers"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:models="using:Raven.Models"
     xmlns:xaml="using:Microsoft.UI.Xaml"
     mc:Ignorable="d">
     <Page.Resources>
         <helpers:EnumToBooleanConverter x:Key="EnumToBooleanConverter" />
+        <helpers:BoolToVisibilityConverter x:Key="BoolToVisibilityConverter" />
     </Page.Resources>
     <Grid>
         <Grid Margin="{StaticResource NavigationViewPageContentMargin}">
@@ -151,6 +153,232 @@
                             HorizontalAlignment="Left"
                             ItemsSource="{x:Bind ViewModel.AllArchitectureNames}"
                             SelectedIndex="{x:Bind ViewModel.SelectedArchitectureIndex, Mode=TwoWay}" />
+                    </Grid>
+                    <Grid
+                        Padding="20"
+                        Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                        BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                        BorderThickness="1"
+                        CornerRadius="8"
+                        RowSpacing="12">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+                        <TextBlock
+                            x:Uid="Settings_Proxy"
+                            Grid.Row="0"
+                            Style="{ThemeResource SubtitleTextBlockStyle}" />
+                        <TextBlock
+                            x:Uid="Settings_ProxyDescription"
+                            Grid.Row="1"
+                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                            Style="{ThemeResource BodyTextBlockStyle}"
+                            TextWrapping="Wrap" />
+
+                        <!--  Saved proxies: radio list, one per entry, plus a Direct option  -->
+                        <!--  Direct connection first, then saved proxies below it.
+                              Negative margins align the proxy circles with the Direct circle.  -->
+                        <RadioButton
+                            x:Uid="Settings_Proxy_Direct"
+                            Grid.Row="3"
+                            Margin="-12,0,0,0"
+                            HorizontalAlignment="Left"
+                            Command="{x:Bind ViewModel.UseDirectConnectionCommand}"
+                            GroupName="ActiveProxy"
+                            IsChecked="{x:Bind ViewModel.IsDirectConnectionSelected, Mode=TwoWay}" />
+
+                        <ListView
+                            Grid.Row="4"
+                            Margin="-12,0,0,0"
+                            IsItemClickEnabled="False"
+                            ItemsSource="{x:Bind ViewModel.Proxies, Mode=OneWay}"
+                            SelectionMode="None">
+                            <ListView.ItemTemplate>
+                                <DataTemplate x:DataType="models:ProxyEntry">
+                                    <Grid
+                                        Padding="8,6"
+                                        ColumnSpacing="8">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="Auto" />
+                                            <ColumnDefinition Width="*" />
+                                            <ColumnDefinition Width="Auto" />
+                                        </Grid.ColumnDefinitions>
+                                        <RadioButton
+                                            Grid.Column="0"
+                                            MinWidth="0"
+                                            Command="{x:Bind ActivateCommand}"
+                                            CommandParameter="{x:Bind}"
+                                            GroupName="ActiveProxy"
+                                            IsChecked="{x:Bind IsActive, Mode=OneWay}" />
+                                        <StackPanel Grid.Column="1" Spacing="0">
+                                            <TextBlock Style="{ThemeResource BodyStrongTextBlockStyle}" Text="{x:Bind Name}" />
+                                            <TextBlock
+                                                Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                                                Style="{ThemeResource CaptionTextBlockStyle}"
+                                                Text="{x:Bind AddressText}" />
+                                        </StackPanel>
+                                        <Button
+                                            x:Uid="Settings_Proxy_RemoveButton"
+                                            Grid.Column="2"
+                                            Padding="8,4"
+                                            VerticalAlignment="Center"
+                                            Command="{x:Bind RemoveCommand}"
+                                            CommandParameter="{x:Bind}">
+                                            <FontIcon
+                                                AutomationProperties.AccessibilityView="Raw"
+                                                FontSize="14"
+                                                Glyph="&#xE74D;" />
+                                        </Button>
+                                    </Grid>
+                                </DataTemplate>
+                            </ListView.ItemTemplate>
+                        </ListView>
+
+                        <InfoBar
+                            x:Uid="Settings_Proxy_Error"
+                            Grid.Row="5"
+                            IsOpen="False"
+                            Visibility="Collapsed"
+                            Severity="Error" />
+
+                        <!--  Add-proxy form  -->
+                        <StackPanel Grid.Row="6" Spacing="8">
+                            <TextBlock x:Uid="Settings_Proxy_AddTitle" Style="{ThemeResource BodyStrongTextBlockStyle}" />
+                            <TextBox
+                                x:Uid="Settings_Proxy_NameBox"
+                                Width="280"
+                                HorizontalAlignment="Left"
+                                Header=""
+                                Text="{x:Bind ViewModel.NewProxyName, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                            <StackPanel Orientation="Horizontal" Spacing="8">
+                                <ComboBox
+                                    x:Uid="Settings_Proxy_TypeCombo"
+                                    MinWidth="120"
+                                    VerticalAlignment="Center"
+                                    ItemsSource="{x:Bind ViewModel.ProxySchemeNames}"
+                                    SelectedIndex="{x:Bind ViewModel.NewProxySchemeIndex, Mode=TwoWay}" />
+                                <TextBox
+                                    x:Name="ProxyHostBox"
+                                    x:Uid="Settings_Proxy_HostBox"
+                                    Width="200"
+                                    VerticalAlignment="Center"
+                                    TextAlignment="Left"
+                                    MaxLength="15"
+                                    TextChanged="ProxyHostBox_TextChanged"
+                                    Text="{x:Bind ViewModel.NewProxyHost, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                                <TextBox
+                                    x:Name="ProxyPortBox"
+                                    x:Uid="Settings_Proxy_PortBox"
+                                    Width="90"
+                                    VerticalAlignment="Center"
+                                    TextAlignment="Left"
+                                    MaxLength="5"
+                                    TextChanged="ProxyPortBox_TextChanged"
+                                    Text="{x:Bind ViewModel.NewProxyPort, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                                <TextBox
+                                    x:Uid="Settings_Proxy_UsernameBox"
+                                    Width="160"
+                                    VerticalAlignment="Center"
+                                    TextAlignment="Left"
+                                    Text="{x:Bind ViewModel.NewProxyUsername, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+                                <PasswordBox
+                                    x:Uid="Settings_Proxy_PasswordBox"
+                                    Width="160"
+                                    VerticalAlignment="Center"
+                                    Password="{x:Bind ViewModel.NewProxyPassword, Mode=TwoWay}" />
+                                <Border
+                                    x:Name="ProxyErrorChip"
+                                    MaxWidth="420"
+                                    Height="32"
+                                    Padding="10,0"
+                                    VerticalAlignment="Center"
+                                    HorizontalAlignment="Left"
+                                    Background="{ThemeResource SubtleFillColorSecondaryBrush}"
+                                    BorderBrush="{ThemeResource SystemFillColorCriticalBrush}"
+                                    BorderThickness="1"
+                                    CornerRadius="4"
+                                    Visibility="{x:Bind ViewModel.HasNewProxyError, Mode=OneWay, Converter={StaticResource BoolToVisibilityConverter}}">
+                                    <StackPanel
+                                        Orientation="Horizontal"
+                                        VerticalAlignment="Center"
+                                        Spacing="6">
+                                        <FontIcon
+                                            AutomationProperties.AccessibilityView="Raw"
+                                            FontSize="14"
+                                            Foreground="{ThemeResource SystemFillColorCriticalBrush}"
+                                            Glyph="&#xE783;" />
+                                        <TextBlock
+                                            x:Uid="Settings_Proxy_Error_Chip"
+                                            VerticalAlignment="Center"
+                                            FontSize="13"
+                                            Foreground="{ThemeResource SystemFillColorCriticalBrush}" />
+                                    </StackPanel>
+                                </Border>
+                            </StackPanel>
+                            <Button
+                                x:Uid="Settings_Proxy_AddButton"
+                                Command="{x:Bind ViewModel.AddProxyCommand}"
+                                Style="{StaticResource AccentButtonStyle}" />
+                        </StackPanel>
+                    </Grid>
+                    <Grid
+                        Padding="20"
+                        Background="{ThemeResource CardBackgroundFillColorDefaultBrush}"
+                        BorderBrush="{ThemeResource CardStrokeColorDefaultBrush}"
+                        BorderThickness="1"
+                        CornerRadius="8"
+                        RowSpacing="10">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+                        <TextBlock
+                            x:Uid="Settings_DownloadFolder"
+                            Grid.Row="0"
+                            Style="{ThemeResource SubtitleTextBlockStyle}" />
+                        <TextBlock
+                            x:Uid="Settings_DownloadFolderDescription"
+                            Grid.Row="1"
+                            Foreground="{ThemeResource TextFillColorSecondaryBrush}"
+                            Style="{ThemeResource BodyTextBlockStyle}"
+                            TextWrapping="Wrap" />
+                        <StackPanel
+                            Grid.Row="2"
+                            Orientation="Horizontal"
+                            Spacing="8">
+                            <FontIcon FontSize="16" Glyph="&#xE8B7;" />
+                            <TextBlock
+                                IsTextSelectionEnabled="True"
+                                Style="{ThemeResource BodyTextBlockStyle}"
+                                Text="{x:Bind ViewModel.EffectiveDownloadFolder, Mode=OneWay}"
+                                TextWrapping="Wrap" />
+                        </StackPanel>
+                        <TextBlock
+                            x:Uid="Settings_DownloadFolder_CurrentLabel"
+                            Grid.Row="3"
+                            Foreground="{ThemeResource TextFillColorTertiaryBrush}"
+                            Style="{ThemeResource CaptionTextBlockStyle}" />
+                        <StackPanel
+                            Grid.Row="4"
+                            Orientation="Horizontal"
+                            Spacing="8">
+                            <Button
+                                x:Uid="Settings_DownloadFolder_BrowseButton"
+                                Command="{x:Bind ViewModel.BrowseDownloadFolderCommand}" />
+                            <Button
+                                x:Uid="Settings_DownloadFolder_ResetButton"
+                                Command="{x:Bind ViewModel.ResetDownloadFolderCommand}"
+                                IsEnabled="{x:Bind ViewModel.IsUsingDefaultDownloadFolderInverse, Mode=OneWay}" />
+                        </StackPanel>
                     </Grid>
                     <Grid
                         Padding="20"

--- a/Raven/Views/SettingsPage.xaml.cs
+++ b/Raven/Views/SettingsPage.xaml.cs
@@ -222,6 +222,91 @@ public sealed partial class SettingsPage : Page
         InitializeComponent();
     }
 
+    // ------------------------------------------------------------------
+    // Proxy input masking
+    // ------------------------------------------------------------------
+
+    // Reentrancy guard: setting sender.Text inside the handler re-fires TextChanging.
+    private bool _isMaskingHost;
+    private bool _isMaskingPort;
+
+    /// <summary>
+    /// Strict IP mask: digits and dots only. Dots the user types are preserved so
+    /// short octets like 127.0.0.1 work; a dot is auto-inserted when a group would
+    /// exceed three digits (---.---.---.---, four groups max).
+    /// </summary>
+    public void ProxyHostBox_TextChanged(object sender, RoutedEventArgs e)
+    {
+        if (_isMaskingHost)
+            return;
+
+        var box = (TextBox)sender;
+        var text = box.Text;
+
+        // Keep only digits and dots.
+        var cleaned = new string(text.Where(c => char.IsAsciiDigit(c) || c == '.').ToArray());
+
+        // Split on user dots; any group longer than three digits is split with
+        // auto-dots at every third digit. Never more than four groups.
+        var groups = new List<string>();
+        foreach (var seg in cleaned.Split('.'))
+        {
+            var remaining = seg;
+            while (remaining.Length > 3)
+            {
+                groups.Add(remaining[..3]);
+                remaining = remaining[3..];
+            }
+            groups.Add(remaining);
+        }
+
+        // Hard cap: four octets; extra digits beyond the fourth group are dropped.
+        if (groups.Count > 4)
+        {
+            var overflow = string.Concat(groups.Skip(3));
+            groups = [.. groups.Take(3), overflow.Length > 3 ? overflow[..3] : overflow];
+        }
+
+        var masked = string.Join('.', groups);
+
+        if (masked != text)
+        {
+            _isMaskingHost = true;
+            try
+            {
+                box.Text = masked;
+                box.SelectionStart = box.Text.Length;
+            }
+            finally
+            {
+                _isMaskingHost = false;
+            }
+        }
+    }
+
+    /// <summary>Port box: digits only (the MaxLength=5 caps it at 65535).</summary>
+    public void ProxyPortBox_TextChanged(object sender, RoutedEventArgs e)
+    {
+        if (_isMaskingPort)
+            return;
+
+        var box = (TextBox)sender;
+        var filtered = new string(box.Text.Where(char.IsAsciiDigit).ToArray());
+        if (filtered != box.Text)
+        {
+            _isMaskingPort = true;
+            try
+            {
+                box.Text = filtered;
+                box.SelectionStart = box.Text.Length;
+            }
+            finally
+            {
+                _isMaskingPort = false;
+            }
+        }
+    }
+
     private async void ResetButton_Click(object sender, RoutedEventArgs e)
     {
         var dialog = new ContentDialog


### PR DESCRIPTION
## Changes

### Proxy support (new feature)
- `IProxyService`, `ProxyService`, `ProxyEntry` - manage multiple proxy entries with runtime switching
- `DownloadLocationService` - configurable download location
- Settings page UI for proxy & download location management (`SettingsPage.xaml` / `.cs`, `SettingsViewModel`)
- New localized strings in `Resources.resw`
- Wired up in `App.xaml.cs`, `ActivationService`, `DownloadManagerService`, `GitHubUpdaterService`, `DownloadHelper`

### StoreListings dependency
This feature needs the proxy-routing changes in the StoreListings submodule (`ProxyManager` + `Helpers.cs`). Those are submitted separately as mjishnu/StoreListings#1. **`.gitmodules` is untouched** - once that PR is merged, this PR's submodule pointer can be bumped to the upstream commit and everything stays on mjishnu/StoreListings. Until then, this branch points the submodule at my fork commit (ddf5abf) so it remains buildable/testable.

All changes built and tested locally (WinUI 3 / .NET 10, x64).